### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sweetnordic/timetracker/security/code-scanning/1](https://github.com/sweetnordic/timetracker/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only checks out the repository and builds a Docker image, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
